### PR TITLE
Fix bug that breaks shadow builds

### DIFF
--- a/platformproxy/platformproxy.pro
+++ b/platformproxy/platformproxy.pro
@@ -19,11 +19,12 @@ TARGET = $$qtLibraryTarget(vncproxy)
 DESTDIR = plugins/platforms
 
 PROJECT_ROOT = $$clean_path( $$PWD/../src )
+BUILD_ROOT = $$clean_path( $$OUT_PWD/../src )
 
 INCLUDEPATH *= $${PROJECT_ROOT}
 DEPENDPATH *= $${PROJECT_ROOT}
 
-LIBS *= -L$${PROJECT_ROOT}/lib -lvncgl
+LIBS *= -L$${BUILD_ROOT}/lib -lvncgl
 
 SOURCES += \
     VncProxyPlugin.cpp


### PR DESCRIPTION
Use `$$OUT_PWD` to refer to the files in the build directory and `$$PWD` for the source tree. This allows shadow building (building into a directory different than the source directory), which is the default behaviour of QtCreator.

This fixes #16