### PR TITLE
Fix missing const & bool return type of stopServer()

### DIFF
--- a/src/VncNamespace.cpp
+++ b/src/VncNamespace.cpp
@@ -245,7 +245,7 @@ namespace Vnc
     bool isAutoStartEnabled() { return vncManager->isAutoStartEnabled(); }
 
     bool startServer( QWindow* w, int port ) { return vncManager->startServer( w, port ); }
-    void stopServer( QWindow* w ) { return vncManager->stopServer( w ); }
+    void stopServer( const QWindow* w ) { vncManager->stopServer( w ); }
 
     QList< QWindow* > windows() { return vncManager->windows(); }
     int serverPort( const QWindow* w ) { return vncManager->serverPort( w ); }

--- a/src/VncNamespace.h
+++ b/src/VncNamespace.h
@@ -110,7 +110,7 @@ namespace Vnc
         \param window Window mirrored by a server
         \sa setAutoStartEnabled(), startServer()
      */
-    VNC_EXPORT bool stopServer( const QWindow* window );
+    VNC_EXPORT void stopServer( const QWindow* window );
 
     /*!
         \return Port used by the VNC server of window


### PR DESCRIPTION
The global function `stopServer()` in the Vnc namespace has some problems: The header declares it as returning `bool`, but the cpp defines it returning `void`. Nevertheless, the cpp returns in its body the return value of invoking the singleton `vncManager`'s member function `stopServer`, which is... `void` again. Also, the header declares the `QWindow *` parameter as `const`, whereas the cpp does not.

This PR aligns the global `stopServer`'s signature with the `VncManager`'s member function's signature, which is returning `void`, taking a `const QWindow *`, and fixes the definition's body by no longer returning something.