### PR TITLE
RfbEncoder: QImageWriter doesn't release unused data from its buffer.

### DIFF
--- a/src/RfbEncoder.cpp
+++ b/src/RfbEncoder.cpp
@@ -49,6 +49,7 @@ namespace
 
         void release() override
         {
+            m_encodedData.resize( 0 );
         }
 
       private:

--- a/src/VncClient.cpp
+++ b/src/VncClient.cpp
@@ -72,7 +72,7 @@ namespace
                 OSSL_PROVIDER_unload( m_provider[0] );
 
             if ( m_provider[1] )
-                OSSL_PROVIDER_unload( m_provider[1]
+                OSSL_PROVIDER_unload( m_provider[1] );
 #endif
         }
 


### PR DESCRIPTION
The size of m_encodedData increases when the encoded jpeg needs more space, but doesn't shrink when the following image needs less memory space.