### PR TITLE
[QT6] Delay frame capture to avoid corrupted output on Qt6

### DIFF
--- a/src/VncServer.cpp
+++ b/src/VncServer.cpp
@@ -157,13 +157,18 @@ void VncServer::addClient( qintptr fd )
     if ( m_window && !m_grabConnectionId )
     {
         /*
-            afterRendering is from the scene graph thread, so we
+            afterRendering and afterFrameEnd are from the scene graph thread, so we
             need a Qt::DirectConnection to avoid, that the image is
             already gone, when being scheduled from a Qt::QQueuedConnection !
          */
 
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
         m_grabConnectionId = QObject::connect( m_window, SIGNAL(afterRendering()),
             this, SLOT(updateFrameBuffer()), Qt::DirectConnection );
+#else
+        m_grabConnectionId = QObject::connect( m_window, SIGNAL(afterFrameEnd()),
+            this, SLOT(updateFrameBuffer()), Qt::DirectConnection );
+#endif
 
         QMetaObject::invokeMethod( m_window, "update" );
     }


### PR DESCRIPTION
In Qt6 afterRendering() signal can fire before the frame is completely ready resulting sometimes in altered output (eg: flipped or color-corrupted image).
Using afterFrameEnd() (introduced in Qt6) seems to guarantee that the frame is ready and RHI has completed its work on it.

Tested on Qt6.8.3